### PR TITLE
Implement Overwrite option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 node_modules/
+.validate.json

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,20 @@
+{
+  "curly": true,
+  "latedef": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "trailing": true,
+
+  "node": true,
+
+  "globals": {
+    "define": false,
+    "describe": false,
+    "it": false,
+    "before": false,
+    "beforeEach": false,
+    "after": false,
+    "afterEach": false
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-test:
-		@./node_modules/.bin/mocha \
-			--reporter spec
-
-.PHONY: test

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Install via NPM
 
 # Usage
 ```
-var mongoose = require("mongoose"),
-    lastModifiedFields = require("lastModifiedFields");
+var mongoose = require('mongoose'),
+    lastModifiedFields = require('lastModifiedFields');
 
 var CarSchema = new mongoose.Schema({
     make:String,
@@ -21,31 +21,43 @@ var CarSchema = new mongoose.Schema({
     miles:Number
 });
 
-CarSchema.plugin(lastModifiedFields, {fieldSuffix:"_lastModified",
-                                      omittedFields:["make", "model"]});
+var options = {
+    fieldSuffix: '_lastModified',
+    omittedFields: ['make', 'model']
+};
+
+CarSchema.plugin(lastModifiedFields, options);
 ```
 
 ###Options
 The plugin currently has the following options
 
 - ####fieldSuffix
-A string to append to the end of each path to determine the name of each timestamp field. Defaults to "_lastModifiedDate"
-    
+A string to append to the end of each path to determine the name of each timestamp field. Defaults to '_lastModifiedDate'
+
 - ####omittedFields
-An array of field names that should not have timestamp fields created for them. 
+An array of field names that should not have timestamp fields created for them.
 Defaults:
-    - Standard id key "**_id**"
-    - Discriminator Key (typically "**__t**")
-    - Version key (typically "**__v**")
-    
+    - Standard id key '**_id**'
+    - Discriminator Key (typically '**__t**')
+    - Version key (typically '**__v**')
+
 - ####purgeFromJSON
-Boolean that transforms the schema's toJSON method to remove the timestamp fields from its JSON representation. Defaults to "false"
+Boolean that transforms the schema's toJSON method to remove the timestamp fields from its JSON representation. Defaults to 'false'
 
 - ####purgeFromObject
-Boolean that transforms the schema's toObject method to remove the timestamp fields from its Object representation. Defaults to "false"
+Boolean that transforms the schema's toObject method to remove the timestamp fields from its Object representation. Defaults to 'false'
+
+- ####overwrite
+Boolean to determine whether the plugin should overwrite _lastModifiedDate fields, even if they were explicitly modified. Defaults to 'true'
+_Note:_ Dates are treated a little differently in mongoose. To be included in `schema.modifiedPaths()`, the date must either be set via `doc.set(...)` or marked explicitly with `doc.markmodified(...)`. A simple assignment does not flag a date as modified. For more information, see http://mongoosejs.com/docs/schematypes.html#Dates.
 
 # Tests
-Test can be run simply by installing and running mocha
+Test can be run by simply running `npm test` or by installing and running mocha.
+
+    npm test
+
+_or:_
 
     npm install -g mocha
     mocha
@@ -55,4 +67,4 @@ Mike Sabatini [@mikesabatini](https://twitter.com/mikesabatini)
 
 #License
 Copyright Mike Sabatini 2014
-Licensed under the MIT License. Enjoy
+Licensed under the MIT License. Enjoy!

--- a/package.json
+++ b/package.json
@@ -4,15 +4,15 @@
   "version": "0.0.3",
   "author": "Mike Sabatini <mike@parallelboxes.com>",
   "dependencies": {
-    "lodash": "3.x"
+    "lodash": "^3.0.0"
   },
   "devDependencies": {
-    "async": "0.2.x",
-    "mocha": "1.14.x",
-    "mongoose": "3.8.x",
+    "async": "^0.9.0",
+    "mocha": "^2.2.1",
+    "mongoose": "^3.8.24",
     "precommit-hook": "^2.0.0",
-    "should": "2.1.x",
-    "sleep": "1.1.x"
+    "should": "^5.2.0",
+    "sleep": "^2.0.0"
   },
   "keywords": [
     "last",

--- a/package.json
+++ b/package.json
@@ -1,32 +1,37 @@
 {
-    "name":"mongoose-schema-lastmodifiedfields",
-    "version":"0.0.2",
-    "description":"mongoose schema plugin to create last modified fields for each field and update them automatically",
-    "main":"index.js",
-    "scripts": {
-        "test":"mocha"
-    },
-    "keywords": [
-        "mongoose",
-        "schema",
-        "modified",
-        "last",
-        "update"
-    ],
-    "author": "Mike Sabatini <mike@parallelboxes.com>",
-    "license":"MIT",
-    "dependencies": {
-        "underscore":"1.5.x"
-    },
-    "devDependencies":{
-        "mocha":"1.14.x",
-        "should":"2.1.x",
-        "mongoose":"3.8.x",
-        "async":"0.2.x",
-        "sleep":"1.1.x"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/sabymike/mongoose-schema-lastmodifiedfields"
-    }
+  "name": "mongoose-schema-lastmodifiedfields",
+  "description": "mongoose schema plugin to create last modified fields for each field and update them automatically",
+  "version": "0.0.3",
+  "author": "Mike Sabatini <mike@parallelboxes.com>",
+  "dependencies": {
+    "lodash": "3.x"
+  },
+  "devDependencies": {
+    "async": "0.2.x",
+    "mocha": "1.14.x",
+    "mongoose": "3.8.x",
+    "precommit-hook": "^2.0.0",
+    "should": "2.1.x",
+    "sleep": "1.1.x"
+  },
+  "keywords": [
+    "last",
+    "modified",
+    "mongoose",
+    "schema",
+    "update"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "pre-commit": [
+    "lint",
+    "test"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sabymike/mongoose-schema-lastmodifiedfields"
+  },
+  "scripts": {
+    "test": "mocha -R spec"
+  }
 }

--- a/test/lastModifiedFieldsSpec.js
+++ b/test/lastModifiedFieldsSpec.js
@@ -1,22 +1,32 @@
-var mongoose = require("mongoose"),
-    _ = require("underscore"),
-    should = require("should"),
-    async = require("async"),
-    sleep = require("sleep"),
-    lastModifiedFields = require("../");
-var Schema = mongoose.Schema;
+var mongoose = require('mongoose'),
+    _ = require('lodash'),
+    async = require('async'),
+    sleep = require('sleep'),
+    lastModifiedFields = require('..');
 
-mongoose.connect(process.env.MONGODB_URL || "mongodb://localhost:27017/mongoose-schema-lastmodifiedfields");
+require('should');
 
-describe("Schema Key Tests", function() {
-    var CarSchema = mongoose.Schema({
-        make: String,
-        model: String,
-        vin: String,
-        miles: Number
-    });
+mongoose.connect(process.env.MONGODB_URL || 'mongodb://localhost:27017/mongoose-schema-lastmodifiedfields');
 
-    var Car = mongoose.model("Car", CarSchema);
+var CarSchema = mongoose.Schema({
+    make: String,
+    model: String,
+    vin: String,
+    miles: Number
+});
+
+var Car = mongoose.model('Car', CarSchema);
+
+var systemKeys = ['_id', CarSchema.options.discriminatorKey, CarSchema.options.versionKey];
+var modifiedFieldSuffix = '_lastModified';
+var omittedFields = ['vin'];
+
+CarSchema.plugin(lastModifiedFields, {
+    fieldSuffix: modifiedFieldSuffix,
+    omittedFields: omittedFields
+});
+
+describe('Schema Key Tests', function() {
 
     beforeEach(function(done) {
         Car.remove({}, function(err) {
@@ -24,144 +34,212 @@ describe("Schema Key Tests", function() {
         });
     });
 
-    var systemKeys = ["_id", CarSchema.options.discriminatorKey, CarSchema.options.versionKey];
-    var modifiedFieldSuffix = "_lastModified";
-    var omittedFields = ['vin'];
-
-    CarSchema.plugin(lastModifiedFields, {fieldSuffix:modifiedFieldSuffix, omittedFields:omittedFields});
-
-    describe("Creating keys", function() {
+    describe('Creating keys', function() {
         before(function() {
             this.schemaPaths = CarSchema.paths;
         });
 
-        it("should not have created a last modified key on system keys", function() {
+        it('should not have created a last modified key on system keys', function() {
             _.each(systemKeys, function(key) {
-                CarSchema.paths.should.not.have.property(key+modifiedFieldSuffix);
+                CarSchema.paths.should.not.have.property(key + modifiedFieldSuffix);
             }, this);
         });
 
-        it("should not have created a last modified key on an omitted field", function() {
+        it('should not have created a last modified key on an omitted field', function() {
             _.each(omittedFields, function(key) {
-                CarSchema.paths.should.not.have.property(key+modifiedFieldSuffix);
+                CarSchema.paths.should.not.have.property(key + modifiedFieldSuffix);
             }, this);
         });
 
-        it("should have created a last modified key for all other user defined properties", function() {
+        it('should have created a last modified key for all other user defined properties', function() {
             _.each(this.schemaPaths, function(pathData) {
                 var pathName = pathData.path;
-                var lastModifiedPathName = pathName+modifiedFieldSuffix;
-                if ( systemKeys.indexOf(pathName) === -1 &&
-                     omittedFields.indexOf(pathName) === -1 &&
-                     pathName.indexOf(modifiedFieldSuffix) === -1 )
-                {
+                var lastModifiedPathName = pathName + modifiedFieldSuffix;
+                if (!_.contains(systemKeys, pathName) &&
+                    !_.contains(omittedFields, pathName) &&
+                    !_.contains(pathName, modifiedFieldSuffix)) {
                     CarSchema.paths.should.have.property(lastModifiedPathName);
                 }
             }, this);
         });
     });
 
-    describe("Outputting models", function() {
-        it("should include the modified fields when converted to json", function(done) {
+    describe('Outputting models', function() {
+        it('should include the modified fields when converted to json', function(done) {
             this.newCar = new Car({
-                make:"Chevy",
-                model:"Tahoe",
-                vin:"12345ABCDE",
-                miles:50000
+                make: 'Chevy',
+                model: 'Tahoe',
+                vin: '12345ABCDE',
+                miles: 50000
             });
 
             this.newCar.save(function(err, car) {
                 var json = car.toJSON();
-                json.should.have.property("make"+modifiedFieldSuffix);
-                json.should.have.property("model"+modifiedFieldSuffix);
-                json.should.have.property("miles"+modifiedFieldSuffix);
+                json.should.have.property('make' + modifiedFieldSuffix);
+                json.should.have.property('model' + modifiedFieldSuffix);
+                json.should.have.property('miles' + modifiedFieldSuffix);
                 done(err);
             });
         });
 
-        it("should strip modified dates if we tell the plugin to purge them from json", function(done) {
-            CarSchema.plugin(lastModifiedFields, {fieldSuffix:modifiedFieldSuffix, omittedFields:omittedFields, purgeFromJSON:true});
+        it('should strip modified dates if we tell the plugin to purge them from json', function(done) {
+            CarSchema.plugin(lastModifiedFields, {
+                fieldSuffix: modifiedFieldSuffix,
+                omittedFields: omittedFields,
+                purgeFromJSON: true
+            });
             this.newCar = new Car({
-                make:"Chevy",
-                model:"Tahoe",
-                vin:"12345ABCDE",
-                miles:50000
+                make: 'Chevy',
+                model: 'Tahoe',
+                vin: '12345ABCDE',
+                miles: 50000
             });
 
             this.newCar.save(function(err, car) {
                 var json = car.toJSON();
-                json.should.not.have.property("make"+modifiedFieldSuffix);
-                json.should.not.have.property("model"+modifiedFieldSuffix);
-                json.should.not.have.property("miles"+modifiedFieldSuffix);
+                json.should.not.have.property('make' + modifiedFieldSuffix);
+                json.should.not.have.property('model' + modifiedFieldSuffix);
+                json.should.not.have.property('miles' + modifiedFieldSuffix);
                 done(err);
             });
         });
 
-        it("should strip modified dates if we tell the plugin to purge them from the object", function(done) {
-            CarSchema.plugin(lastModifiedFields, {fieldSuffix:modifiedFieldSuffix, omittedFields:omittedFields, purgeFromObject:true});
+        it('should strip modified dates if we tell the plugin to purge them from the object', function(done) {
+            CarSchema.plugin(lastModifiedFields, {
+                fieldSuffix: modifiedFieldSuffix,
+                omittedFields: omittedFields,
+                purgeFromObject: true
+            });
             this.newCar = new Car({
-                make:"Chevy",
-                model:"Tahoe",
-                vin:"12345ABCDE",
-                miles:50000
+                make: 'Chevy',
+                model: 'Tahoe',
+                vin: '12345ABCDE',
+                miles: 50000
             });
 
             this.newCar.save(function(err, car) {
                 var obj = car.toObject();
-                obj.should.not.have.property("make"+modifiedFieldSuffix);
-                obj.should.not.have.property("model"+modifiedFieldSuffix);
-                obj.should.not.have.property("miles"+modifiedFieldSuffix);
+                obj.should.not.have.property('make' + modifiedFieldSuffix);
+                obj.should.not.have.property('model' + modifiedFieldSuffix);
+                obj.should.not.have.property('miles' + modifiedFieldSuffix);
                 done(err);
             });
         });
     });
 
-    describe("Saving models", function() {
+    describe('Saving models', function() {
         beforeEach(function() {
             this.newCar = new Car({
-                make:"Honda",
-                model:"Civic",
-                vin:"12345ABCDE",
-                miles:20000
+                make: 'Honda',
+                model: 'Civic',
+                vin: '12345ABCDE',
+                miles: 20000
             });
         });
 
-        it("should set the current date on all the last modified fields when saving the first time", function(done) {
+        it('should set the current date on all the last modified fields when saving the first time', function(done) {
             var now = new Date();
             this.newCar.save(function(err, car) {
-                car.get("make"+modifiedFieldSuffix).should.be.approximately(now, 1);
-                car.get("model"+modifiedFieldSuffix).should.be.approximately(now, 1);
-                car.get("miles"+modifiedFieldSuffix).should.be.approximately(now, 1);
+                car.get('make' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                car.get('model' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                car.get('miles' + modifiedFieldSuffix).should.be.approximately(now, 1);
                 done(err);
             });
         });
 
-        it("should only update the last modified fields for the paths that have been changed on later saves", function(done) {
+        it('should only update the last modified fields for the paths that have been changed on later saves', function(done) {
+            // give this test 3 seconds to complete because we sleep to make sure our timestamps differ
+            this.timeout(3000);
+
+            var self = this;
+            async.series([
+                    function(callback) {
+                        self.newCar.save(callback);
+                    },
+                    function(callback) {
+                        sleep.sleep(2);
+                        self.newCar.make = 'Volkswagon';
+                        self.newCar.model = 'Jetta';
+                        var now = new Date();
+                        self.newCar.save(function(err, car) {
+                            car.get('make' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('model' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('miles' + modifiedFieldSuffix).should.not.be.approximately(now, 1);
+                            callback(err);
+                        });
+                    }
+                ],
+                done);
+        });
+
+        it('should not overwrite modified dates if explicitly set and we tell the plugin to skip', function(done) {
+            CarSchema.plugin(lastModifiedFields, {
+                fieldSuffix: modifiedFieldSuffix,
+                omittedFields: omittedFields,
+                overwrite: false
+            });
+
             // give this test 5 seconds to complete because we sleep to make sure our timestamps differ
             this.timeout(5000);
 
             var self = this;
             async.series([
-                function(callback) {
-                    self.newCar.save(function(err) {
-                        callback(err);
-                    });
-                },
-                function(callback) {
-                    sleep.sleep(2);
-                    self.newCar.make = "Volkswagon";
-                    self.newCar.model = "Jetta";
-                    var now = new Date();
-                    self.newCar.save(function(err, car) {
-                        car.get("make"+modifiedFieldSuffix).should.be.approximately(now, 1);
-                        car.get("model"+modifiedFieldSuffix).should.be.approximately(now, 1);
-                        car.get("miles"+modifiedFieldSuffix).should.not.be.approximately(now, 1);
-                        callback(err);
-                    });
-                }],
-                function(err, result) {
-                    done(err);
-                });
+                    function(callback) {
+                        self.newCar.save(callback);
+                    },
+                    function(callback) {
+                        sleep.sleep(2);
+                        var now = new Date();
+                        self.newCar.make = 'Volkswagon';
+                        self.newCar.set('make' + modifiedFieldSuffix, now);
+                        self.newCar.model = 'Jetta';
+                        self.newCar.set('model' + modifiedFieldSuffix, now);
+                        sleep.sleep(2);
+                        self.newCar.save(function(err, car) {
+                            car.get('make' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('model' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('miles' + modifiedFieldSuffix).should.not.be.approximately(now, 1);
+                            callback(err);
+                        });
+                    }
+                ],
+                done);
         });
+
+        it('should overwrite modified dates even if explicitly set and overwrite option is true', function(done) {
+            CarSchema.plugin(lastModifiedFields, {
+                fieldSuffix: modifiedFieldSuffix,
+                omittedFields: omittedFields,
+                overwrite: true
+            });
+
+            // give this test 5 seconds to complete because we sleep to make sure our timestamps differ
+            this.timeout(5000);
+
+            var self = this;
+            async.series([
+                    function(callback) {
+                        self.newCar.save(callback);
+                    },
+                    function(callback) {
+                        sleep.sleep(2);
+                        var now = new Date();
+                        self.newCar.make = 'Volkswagon';
+                        self.newCar.set('make' + modifiedFieldSuffix, now);
+                        self.newCar.model = 'Jetta';
+                        self.newCar.set('model' + modifiedFieldSuffix, now);
+                        sleep.sleep(2);
+                        now = new Date();
+                        self.newCar.save(function(err, car) {
+                            car.get('make' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('model' + modifiedFieldSuffix).should.be.approximately(now, 1);
+                            car.get('miles' + modifiedFieldSuffix).should.not.be.approximately(now, 1);
+                            callback(err);
+                        });
+                    }
+                ],
+                done);
+        });
+
     });
 });

--- a/test/lastModifiedFieldsSpec.js
+++ b/test/lastModifiedFieldsSpec.js
@@ -240,6 +240,58 @@ describe('Schema Key Tests', function() {
                 ],
                 done);
         });
+    });
+
+    describe('Mongoose oddities', function() {
+        beforeEach(function() {
+
+            this.newCar = new Car({
+                make: 'Subaru',
+                model: 'Outback',
+                vin: '12345ABCDE',
+                miles: 100000
+            });
+        });
+
+        it('should not have lastModifiedFields in modifiedPaths() when assigned', function(done) {
+            // give this test 3 seconds to complete because we sleep to make sure our timestamps differ
+            this.timeout(3000);
+
+            this.newCar.save(function(err, car) {
+                sleep.sleep(2);
+                car.make = 'Volkswagon';
+                car['make' + modifiedFieldSuffix] = new Date();
+                car.modifiedPaths().should.not.containEql(['make' + modifiedFieldSuffix]);
+                done(err);
+            });
+        });
+
+        it('should have lastModifiedFields in modifiedPaths() after calling `markModified`', function(done) {
+            // give this test 3 seconds to complete because we sleep to make sure our timestamps differ
+            this.timeout(3000);
+
+            this.newCar.save(function(err, car) {
+                sleep.sleep(2);
+                car.make = 'Volkswagon';
+                car['make' + modifiedFieldSuffix] = new Date();
+                car.markModified('make' + modifiedFieldSuffix);
+                car.modifiedPaths().should.eql(['make', 'make' + modifiedFieldSuffix]);
+                done(err);
+            });
+        });
+
+        it('should have lastModifiedFields in modifiedPaths() when explicitly `set`', function(done) {
+            // give this test 3 seconds to complete because we sleep to make sure our timestamps differ
+            this.timeout(3000);
+
+            this.newCar.save(function(err, car) {
+                sleep.sleep(2);
+                car.make = 'Volkswagon';
+                car.set('make' + modifiedFieldSuffix, new Date());
+                car.modifiedPaths().should.eql(['make', 'make' + modifiedFieldSuffix]);
+                done(err);
+            });
+        });
 
     });
 });


### PR DESCRIPTION
Add a option to plugin, so that when a lastModifie is explictly set or
marked as modified, the plug will not overwrite that value. Not sure if
"overwrite" is the best name. Implementation with default of true will
maintain backward compatibility.

Added a couple tests around the new "overwrite" option.

Also, linting/beautification.
Switched out `underscore` for `lodash`.
And I love 'precommit-hook' for linting and test enforcement, so I threw
that in as well.
