### PR TITLE
Fix for embedded schema types

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ module.exports = exports = function lastModifiedFields(schema, options) {
                 type: Date
             });
             if (_.has(options, 'select')) {
-                addObj[pathName].select = options.select; // set default select behavior
+                _.set(addObj, pathName + '.select', options.select); // set default select behavior
             }
             schema.add(addObj);
         }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mongoose-schema-lastmodifiedfields",
   "description": "mongoose schema plugin to create last modified fields for each field and update them automatically",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Mike Sabatini <mike@parallelboxes.com>",
   "dependencies": {
     "lodash": "^3.7.0"


### PR DESCRIPTION
A schema with an embedded type (aka sub schema) was throwing an error because `addObj[pathName]` could not be resolved. `pathName` in this case would be something like `prop.subprop` and javascript doesn't handle this. `lodash.set` FTW!

For the "Embedded" tests, I needed to redefine `CarSchema` and the `Car` model with an embedded type. So I decided to move the original declaration into a `before` block inside the first `describe`. `this` prefixing was subsequently necessary- hence all the changed lines.
